### PR TITLE
fix bug introduced yesterday while fixing linting issues

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -176,16 +176,6 @@ type uploadGetRequest struct {
 }
 
 func decodeUploadGetRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error reading body: %w", err)
-	}
-	var metaRequest MetaRequest
-	err = json.Unmarshal(bodyBytes, &metaRequest)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing meta json: %w", err)
-	}
-
 	return uploadGetRequest{
 		typ:    r.FormValue("type"),
 		name:   r.FormValue("name"),


### PR DESCRIPTION
fixing a linting issue (unchecked error) introduced a new bug the ignored error was not nil, because it was trying to examine the body of a GET request, which was empty as expected

this was most likely a copy/paste bug from earlier in development